### PR TITLE
Booleans are not strings

### DIFF
--- a/tests/examples_output/Autoscaling.template
+++ b/tests/examples_output/Autoscaling.template
@@ -129,13 +129,13 @@
             "Type": "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy": {
                 "AutoScalingReplacingUpdate": {
-                    "WillReplace": "true"
+                    "WillReplace": true
                 },
                 "AutoScalingRollingUpdate": {
                     "MaxBatchSize": "1",
                     "MinInstancesInService": "1",
                     "PauseTime": "PT5M",
-                    "WaitOnResourceSignals": "true"
+                    "WaitOnResourceSignals": true
                 }
             }
         },
@@ -181,8 +181,8 @@
                         "services": {
                             "sysvinit": {
                                 "rsyslog": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/rsyslog.d/20-somethin.conf"
                                     ]

--- a/tests/examples_output/AutoscalingHTTPRequests.template
+++ b/tests/examples_output/AutoscalingHTTPRequests.template
@@ -129,13 +129,13 @@
             "Type": "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy": {
                 "AutoScalingReplacingUpdate": {
-                    "WillReplace": "true"
+                    "WillReplace": true
                 },
                 "AutoScalingRollingUpdate": {
                     "MaxBatchSize": "1",
                     "MinInstancesInService": "1",
                     "PauseTime": "PT5M",
-                    "WaitOnResourceSignals": "true"
+                    "WaitOnResourceSignals": true
                 }
             }
         },
@@ -218,8 +218,8 @@
                         "services": {
                             "sysvinit": {
                                 "rsyslog": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/rsyslog.d/20-somethin.conf"
                                     ]

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -35,12 +35,12 @@
                 "DistributionConfig": {
                     "DefaultCacheBehavior": {
                         "ForwardedValues": {
-                            "QueryString": "false"
+                            "QueryString": false
                         },
                         "TargetOriginId": "Origin 1",
                         "ViewerProtocolPolicy": "allow-all"
                     },
-                    "Enabled": "true",
+                    "Enabled": true,
                     "HttpVersion": "http2",
                     "Origins": [
                         {

--- a/tests/examples_output/ECSCluster.template
+++ b/tests/examples_output/ECSCluster.template
@@ -89,8 +89,8 @@
                         },
                         "services": {
                             "cfn-hup": {
-                                "enabled": "true",
-                                "ensureRunning": "true",
+                                "enabled": true,
+                                "ensureRunning": true,
                                 "files": [
                                     "/etc/cfn/cfn-hup.conf",
                                     "/etc/cfn/hooks.d/cfn-auto-reloader.conf"

--- a/tests/examples_output/ECSFargate.template
+++ b/tests/examples_output/ECSFargate.template
@@ -36,7 +36,7 @@
             "Properties": {
                 "ContainerDefinitions": [
                     {
-                        "Essential": "true",
+                        "Essential": true,
                         "Image": "nginx",
                         "Name": "nginx",
                         "PortMappings": [

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -199,7 +199,7 @@
                                     "VolumesPerInstance": "1"
                                 }
                             ],
-                            "EbsOptimized": "true"
+                            "EbsOptimized": true
                         },
                         "InstanceCount": "1",
                         "InstanceType": "m4.large",

--- a/tests/examples_output/ElastiCacheRedis.template
+++ b/tests/examples_output/ElastiCacheRedis.template
@@ -527,16 +527,16 @@
                         "services": {
                             "sysvinit": {
                                 "cfn-hup": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/cfn/cfn-hup.conf",
                                         "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
                                     ]
                                 },
                                 "httpd": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true"
+                                    "enabled": true,
+                                    "ensureRunning": true
                                 }
                             }
                         }

--- a/tests/examples_output/ElasticsearchDomain.template
+++ b/tests/examples_output/ElasticsearchDomain.template
@@ -21,18 +21,18 @@
                 },
                 "DomainName": "ExampleElasticsearchDomain",
                 "EBSOptions": {
-                    "EBSEnabled": "true",
+                    "EBSEnabled": true,
                     "Iops": 0,
                     "VolumeSize": 20,
                     "VolumeType": "gp2"
                 },
                 "ElasticsearchClusterConfig": {
                     "DedicatedMasterCount": 3,
-                    "DedicatedMasterEnabled": "true",
+                    "DedicatedMasterEnabled": true,
                     "DedicatedMasterType": "m3.medium.elasticsearch",
                     "InstanceCount": 2,
                     "InstanceType": "m3.medium.elasticsearch",
-                    "ZoneAwarenessEnabled": "true"
+                    "ZoneAwarenessEnabled": true
                 },
                 "SnapshotOptions": {
                     "AutomatedSnapshotStartHour": 0

--- a/tests/examples_output/Firehose_with_Redshift.template
+++ b/tests/examples_output/Firehose_with_Redshift.template
@@ -7,7 +7,7 @@
                 "DeliveryStreamName": "MyDeliveryStream",
                 "RedshiftDestinationConfiguration": {
                     "CloudWatchLoggingOptions": {
-                        "Enabled": "true",
+                        "Enabled": true,
                         "LogGroupName": "my-log-group",
                         "LogStreamName": "my-log-stream"
                     },
@@ -26,7 +26,7 @@
                             "SizeInMBs": 60
                         },
                         "CloudWatchLoggingOptions": {
-                            "Enabled": "true",
+                            "Enabled": true,
                             "LogGroupName": "my-other-log-group",
                             "LogStreamName": "my-other-log-stream"
                         },

--- a/tests/examples_output/IoTSample.template
+++ b/tests/examples_output/IoTSample.template
@@ -53,7 +53,7 @@
                             }
                         }
                     ],
-                    "RuleDisabled": "true",
+                    "RuleDisabled": true,
                     "Sql": "SELECT temp FROM SomeTopic WHERE temp > 60"
                 }
             },

--- a/tests/examples_output/OpenStack_AutoScaling.template
+++ b/tests/examples_output/OpenStack_AutoScaling.template
@@ -59,8 +59,8 @@
                         "services": {
                             "sysvinit": {
                                 "service1": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/service1/somefile.conf"
                                     ]

--- a/tests/examples_output/VPC_single_instance_in_subnet.template
+++ b/tests/examples_output/VPC_single_instance_in_subnet.template
@@ -585,16 +585,16 @@
                         "services": {
                             "sysvinit": {
                                 "cfn-hup": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/cfn/cfn-hup.conf",
                                         "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
                                     ]
                                 },
                                 "httpd": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true"
+                                    "enabled": true,
+                                    "ensureRunning": true
                                 }
                             }
                         }
@@ -627,8 +627,8 @@
                 },
                 "NetworkInterfaces": [
                     {
-                        "AssociatePublicIpAddress": "true",
-                        "DeleteOnTermination": "true",
+                        "AssociatePublicIpAddress": true,
+                        "DeleteOnTermination": true,
                         "DeviceIndex": "0",
                         "GroupSet": [
                             {

--- a/tests/examples_output/WAF_Common_Attacks_Sample.template
+++ b/tests/examples_output/WAF_Common_Attacks_Sample.template
@@ -38,7 +38,7 @@
                         "DataId": {
                             "Ref": "WAFManualIPBlockSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "IPMatch"
                     }
                 ]
@@ -126,7 +126,7 @@
                         "DataId": {
                             "Ref": "SizeMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SizeConstraint"
                     }
                 ]
@@ -236,7 +236,7 @@
                         "DataId": {
                             "Ref": "SqliMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SqlInjectionMatch"
                     }
                 ]
@@ -326,7 +326,7 @@
                         "DataId": {
                             "Ref": "XssMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "XssMatch"
                     }
                 ]

--- a/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
+++ b/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
@@ -38,7 +38,7 @@
                         "DataId": {
                             "Ref": "WAFManualIPBlockSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "IPMatch"
                     }
                 ]
@@ -126,7 +126,7 @@
                         "DataId": {
                             "Ref": "SizeMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SizeConstraint"
                     }
                 ]
@@ -236,7 +236,7 @@
                         "DataId": {
                             "Ref": "SqliMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SqlInjectionMatch"
                     }
                 ]
@@ -326,7 +326,7 @@
                         "DataId": {
                             "Ref": "XssMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "XssMatch"
                     }
                 ]

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -1,0 +1,20 @@
+import unittest
+from troposphere import cloudfront
+
+
+class TestCloudfront(unittest.TestCase):
+
+    def test_logging(self):
+
+        logging = cloudfront.Logging(
+            Bucket='mytestbucket',
+            IncludeCookies=True,
+            Prefix='myprefix',
+        )
+
+        d = logging.to_dict()
+        self.assertEquals(d['IncludeCookies'], True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -50,7 +50,7 @@ def is_aws_object_subclass(cls):
     return is_aws_object
 
 
-def encode_to_dict(obj):
+def encode_to_dict(obj, hints=None):
     if hasattr(obj, 'to_dict'):
         # Calling encode_to_dict to ensure object is
         # nomalized to a base dictionary all the way down.
@@ -63,13 +63,21 @@ def encode_to_dict(obj):
     elif isinstance(obj, dict):
         props = {}
         for name, prop in obj.items():
-            props[name] = encode_to_dict(prop)
+            validator = None
+            if isinstance(hints, dict):
+                hint = hints.get(name)
+                if hint is not None:
+                    validator = hint[0]
+            props[name] = encode_to_dict(prop, validator)
 
         return props
     # This is useful when dealing with external libs using
     # this format. Specifically awacs.
     elif hasattr(obj, 'JSONrepr'):
         return encode_to_dict(obj.JSONrepr())
+
+    if hints == validators.boolean:
+        return str(obj).lower() in ("yes", "true", "t", "1")
     return obj
 
 
@@ -244,7 +252,7 @@ class BaseAWSObject(object):
             self.validate()
 
         if self.properties:
-            return encode_to_dict(self.resource)
+            return encode_to_dict(self.resource, hints=self.props)
         elif hasattr(self, 'resource_type'):
             d = {}
             for k, v in self.resource.items():


### PR DESCRIPTION
In order to be correctly interpreted by the YAML processor boolean values must not be quoted. This change uses the fields property validator to provide a hint to the fields type and if it is a boolean output the native Python type, [True|False],